### PR TITLE
Remove ES6 destructuring

### DIFF
--- a/regl-camera.js
+++ b/regl-camera.js
@@ -110,10 +110,10 @@ function createCamera (regl, props_) {
 
   var injectContext = regl({
     context: Object.assign({}, cameraState, {
-      projection: function ({viewportWidth, viewportHeight}) {
+      projection: function (context) {
         perspective(cameraState.projection,
           cameraState.fovy,
-          viewportWidth / viewportHeight,
+          context.viewportWidth / context.viewportHeight,
           cameraState.near,
           cameraState.far)
         if (cameraState.flipY) { cameraState.projection[5] *= -1 }


### PR DESCRIPTION
I'm guessing the intention is that this module is ES5 only for compatibility with widest range of browsers and with UglifyJS etc.
